### PR TITLE
17_プロジェクトの構成管理_Gradle_Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	//Apache Commons Lang（便利機能、ユーティリティ）
+	implementation 'org.apache.commons:commons-lang3:3.14.0'
+
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## 課題内容
 - build.gradleにユーティリティを追加
 
## 授業内容

Maven repositoryのホームページから、
（https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.14.0#gradle-short）

- build.gradleにユーティリティを追加する

①

<img width="868" alt="スクリーンショット 2024-10-15 20 54 15" src="https://github.com/user-attachments/assets/7f86dca6-1e61-46e2-afe5-2f4d4db2fad8">


②

<img width="617" alt="スクリーンショット 2024-10-15 20 54 24" src="https://github.com/user-attachments/assets/9085ff04-fc85-4500-afde-ba41f7471869">


③

<img width="592" alt="スクリーンショット 2024-10-18 13 53 15" src="https://github.com/user-attachments/assets/829f0d4a-4114-416d-82e1-0b0704ac2e4a">




 
※セルフマージする